### PR TITLE
Correctly subclass tibble

### DIFF
--- a/R/gaze.R
+++ b/R/gaze.R
@@ -181,8 +181,9 @@ gaze.formula_sub=function(x,data,missing=FALSE,...){
          df=bind_rows(df,temp)
        }
      }
-     attr(df,"yvars")=yvars
-     class(df)=c("gaze","data.frame","tibble")
+     df <- as_tibble(df)
+     attr(df, "yvars") <- yvars
+     class(df) <- c("gaze", class(df))
      df
 }
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

When creating your gaze class, you were incorrectly placing the `tibble` class _after_ `data.frame`. This is invalid, and some changes in dplyr revealed this bug. You should use `class(df) <- c("myclass", class(df))` or `tibble::new_tibble()` for this. I prefer `tibble::new_tibble()` but it looks like you are already at 20 import dependencies and you get a CRAN note if you add another, so I used the first way to fix this.

We plan to submit dplyr 1.1.1 in 2-3 weeks.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!